### PR TITLE
Fix infoblokken lines

### DIFF
--- a/Effecten.md
+++ b/Effecten.md
@@ -55,6 +55,7 @@ Voorbeeld:
 Resultaat: ==gemarkeerde teskst==
 
 > [!missing] Underlined tekst
+> 
 > Tekst met een underline is niet beschikbaar binnen markdown, deze tekst is lastig te lezen en wordt geassocieerd met links.
 
 ### Combineren van meerdere effecten

--- a/Infoblokken en quotes.md
+++ b/Infoblokken en quotes.md
@@ -28,21 +28,25 @@ Resultaat:
 
 ## Infoblokken
 
-Markdown ondersteunt ook infoblokken die gebruikt kunnen worden om informatie op een opvallende manier weer te geven. Dit kan worden gedaan door `[!info]`, `[!tip]` of andere specifieke bloktypes aan het begin van de quote te plaatsen.
+Markdown ondersteunt ook infoblokken die gebruikt kunnen worden om informatie op een opvallende manier weer te geven. Dit kan worden gedaan door `[!info]`, `[!tip]` of andere specifieke bloktypes aan het begin van de quote te plaatsen. Vergeet niet een lege lijn met alleen `>` tussen de titel en inhoud van dit blok te zetten.
 
 Hier is een voorbeeld van een infoblok:
 
 ```
 > [!info] infoblokken
+> 
 > Een quote kan ook in een infoblok worden veranderd door er `[!info]` of `[!tip]` voor te zetten. Ook kan de naam van het blok veranderd worden door de naam op de eerste lijn na `]` te zetten.
 > > [!example]+ Nested infoblokken zijn ook mogelijk
+> > 
 > > Door een `+` of `-` na de `]` toe te voegen kan deze ook ingevouwen worden.
 ```
 
 > [!info] infoblokken
+> 
 > Een quote kan ook in een infoblok worden veranderd door er `[!info]` of `[!tip]` voor te zetten. Ook kan de naam van het blok veranderd worden door de naam op de eerste lijn na `]` te zetten.
 > > [!example]+ Nested infoblokken zijn ook mogelijk
-> > Door een `+` of `-` na de `]` toe te voegen kan deze ook ingevouwen worden.
+> > 
+> > Door een `+` of `-` na de `]` toe te voegen kunnen deze ook ingevouwen worden.
 
 ### Types/iconen van infoblokken
 
@@ -50,7 +54,9 @@ Er zijn verschillende types en bijbehorende icoontjes die gebruikt kunnen worden
 
 
 > [!example]- Voorbeeld iconen
+> 
 > > [!abstract]-
+> > 
 > >Kan ook met `summary` of `tldr` gemaakt worden.
 > 
 > >[!note]
@@ -60,15 +66,19 @@ Er zijn verschillende types en bijbehorende icoontjes die gebruikt kunnen worden
 > >[!todo]
 > 
 > >[!tip]-
+> >
 > > Kan ook met `hint` of `important` gemaakt worden.
 > 
 > >[!success]-
+> >
 > > Kan ook met `check` of `done` gemaakt worden.
 > 
 > >[!failure]-
+> >
 > > Kan ook met `fail` of `missing` gemaakt worden.
 > 
 > >[!danger]-
+> >
 > > Kan ook met `error` gemaakt worden.
 > 
 > >[!bug]
@@ -76,6 +86,7 @@ Er zijn verschillende types en bijbehorende icoontjes die gebruikt kunnen worden
 > > [!example]
 > 
 > > [!quote]-
+> > 
 > > Kan ook met `cite` gemaakt worden
 
 
@@ -89,4 +100,5 @@ Hier is een voorbeeld van hoe een `tip` blok gemaakt kan worden:
 Resultaat:
 
 > [!tip] Dit is een tip! 
+> 
 > Tips kunnen handige informatie bevatten die de lezer helpt.

--- a/LaTeX/Effecten.md
+++ b/LaTeX/Effecten.md
@@ -69,6 +69,7 @@ Een vaker voorkomende notatie voor vectoren zijn pijlen. LaTeX beschikt ook over
 Deze effecten kunnen gebruikt worden om geschatte variabelen en de Fourier-analyse aan te geven. Dit gaat met behulp van de `widehat` en `widetilde` tags gevolgd door de tekst waar het effect nodig is.
 
 >[!example]- Voorbeeld dakjes en tildes
+>
 >Schattingen kunnen aangegeven worden met een $\widehat{}$.
 >```
 >$\widehat{Y} = a + bx$
@@ -92,6 +93,7 @@ Deze effecten kunnen gebruikt worden om geschatte variabelen en de Fourier-analy
 Braces kunnen gebruikt worden om extra context te geven in een formule, dit kan bijvoorbeeld bij een onderdeel van een formule of bij sommatie. Zoals de andere effecten kunnen deze aangeroepen worden met `\overbrace` en `\underbrace` gevolgd door een underscore (`_`) of caret-symbool (`^`) met de tekst respectievelijk.
 
 >[!example]- Voorbeeld braces
+>
 >Braces kunnen gebruikt worden om een deel van een formule duidelijker te maken:
 >```
 >$Y = \underbrace{a + bx}_{\text{formule van de lijn}}$

--- a/LaTeX/Matrixen.md
+++ b/LaTeX/Matrixen.md
@@ -51,6 +51,7 @@ c & d
 $$
 
 > [!example]- Matrixen met haakjes
+> 
 > |**Type**|**Code**|**Resultaat**|
 > |:-|:-|:-:|
 > |`matrix`|`$\begin{matrix} a & b \\ c & d \end{matrix}$`| $\begin{matrix} a & b \\ c & d \end{matrix}$ |
@@ -75,6 +76,7 @@ De matrix is: $\begin{smallmatrix} a & b \\ c & d \end{smallmatrix}$
 net zoals bij normale matrixes kunnen p, b, B, v en V hiervoor gezet worden om scheidingstekens toe te voegen.
 
 > [!example]- Smallmatrixen met haakjes
+> 
 > |**Type**|**Code**|**Resultaat**|
 > |:-|:-|:-:|
 > |`smallmatrix`|`$\begin{smallmatrix} a & b \\ c & d \end{smallmatrix}$` | $\begin{smallmatrix} a & b \\ c & d \end{smallmatrix}$ |
@@ -85,6 +87,7 @@ net zoals bij normale matrixes kunnen p, b, B, v en V hiervoor gezet worden om s
 > |`Vsmallmatrix`|`$\begin{Vsmallmatrix} a & b \\ c & d \end{Vsmallmatrix}$` | $\begin{Vsmallmatrix} a & b \\ c & d \end{Vsmallmatrix}$ |
 
 >[!danger] Leesbaarheid smallmatrix
+>
 >smallmatrix is niet altijd goed leesbaar, probeer hier voor slechtziende gebruikers rekening mee te houden.
 
 ## Eigen scheidingstekens
@@ -110,6 +113,7 @@ d & e & f
 $$
 
 > [!example]- Beschikbare scheidingstekens
+> 
 > |**Teken**|**Code**|**Resultaat**|
 > |:-|:-|:-:|
 > |`[]`|`$$\left[ \begin{smallmatrix} a & b \\ c & d \end{smallmatrix} \right]$$`|$$\left[ \begin{smallmatrix} a & b \\ c & d \end{smallmatrix} \right]$$|

--- a/LaTeX/Symbolen.md
+++ b/LaTeX/Symbolen.md
@@ -23,6 +23,7 @@ de meeste basisoperatoren (+, -, =, <, >) zijn als tekst binnen LaTeX te gebruik
 | Deling            | `$a \div b$`                  | $a \div b$                  |
 
 >[!tip] Deling en fracties
+>
 > Voor betere leesbaarheid en consistentie is het aangeraden om [[Uitdrukkingen#Fracties|fracties]] in plaats van deling te gebruiken, vooral in grotere functies. Dit voorkomt onduidelijkheden en is consistent met de conventies.
 
 ## Niet-Latijnse karakters 
@@ -38,6 +39,7 @@ Resultaat:
 Met behulp van LaTeX kunnen symbolen zoals $\aleph$ en $\Delta$ gemakkelijk gebruikt worden!
 
 > [!example]- Lijst van karakters
+> 
 > Door de eerste letter een hoofdletter te maken wordt de hoofdletter gebruikt:
 >  `delta`$\delta$ $\rightarrow$ `Delta` $\Delta$
 > Dit is niet beschikbaar voor elke letter omdat sommige letters hetzelfde zijn als in het latijnse alfabet.

--- a/LaTeX/Uitdrukkingen.md
+++ b/LaTeX/Uitdrukkingen.md
@@ -87,6 +87,7 @@ log_{10}(100)
 $$
 
 >[!tip] Basis van logaritmes
+>
 >Probeer altijd een basis mee te geven aan een logaritme. Dit voorkomt verwarring omdat de "standaard" basis 10 of $e$ kan zijn.
 
 ### Sommatie en Product

--- a/Links.md
+++ b/Links.md
@@ -31,6 +31,7 @@ Resultaat:
 Andere bestanden kunnen ook gelinkt worden, bijvoorbeeld de [[index|homepagina]]! 
 
 > [!tip]
+> 
 > Probeer in plaats van "De informatie kan [[Links#Bestanden binnen de wiki|hier]] gevonden worden." de relevante woord(en) als link aan te geven bijvoorbeeld:
 > > Hier is kennis over het [[Links#Bestanden binnen de wiki|linken van bestanden]] voor nodig.
 > 

--- a/zzzzbugs.md
+++ b/zzzzbugs.md
@@ -5,3 +5,4 @@ draft: true
 - `|` in code in tabel
 - `%%` comments in code escapen?
 - \\ binnen inline codeblok is niet zichtbaar in editor tenzij geselecteerd: `\`
+- obsidian rendered callouts zonder regel tussen titel en content wel maar quartz niet


### PR DESCRIPTION
er moet na de titel van een infoblok een newline. obsidian werkt zonder deze enwline maart quartz niet